### PR TITLE
Refactor the outline

### DIFF
--- a/outline.md
+++ b/outline.md
@@ -312,9 +312,64 @@ TODO: Add acceptance test for our blog post models showing up
 
 ### 11. Additional Blog post route(s)
 
-0. Add show route with template.
-0. Paginate homepage?
-0. Make archive page for previous blog posts?
+What if we want to share a link to one of our blog posts?  To do that, we would need a page for each blog post.  Let's make those!
+
+#### Create the route
+
+Let's start by using a generator to make the new files we'll need:
+
+    $ ember generate route blogPost --type=resource --path=/post/:blog_post_id
+    version: 0.2.1
+    installing
+      create app/routes/blog-post.js
+        create app/templates/blog-post.hbs
+        installing
+          create tests/unit/routes/blog-post-test.js
+
+This creates a few files, and also adds a  `app/router.js`:
+
+    import Ember from 'ember';
+    import config from './config/environment';
+
+    var Router = Ember.Router.extend({
+      location: config.locationType
+    });
+
+    Router.map(function() {
+      this.resource('blogPost', {
+        path: '/post/:blog_post_id'
+      }, function() {});
+    });
+
+    export default Router;
+
+TODO: Should we add a store lookup to our route.js file even though it's done automagically?
+
+#### Update the template
+
+Now let's add the following to our `app/blog-post.hbs` template file to display our post on the page:
+
+    <article>
+      <h2>{{model.title}}</h2>
+      {{model.body}}
+    </article>
+
+If we visit `http://localhost:4200/post/1` in our browser, we should see an example blog post.
+
+#### Handlebars link-to helper
+
+Now that we have unique URLs for each blog post, we need to link to these URLs.
+
+To add these links open up the `app/templates/index.hbs` file and add a `{{link-to}}` helper:
+
+    {{#each model as |post|}}
+    <article>
+      <h2>{{#link-to 'blogPost' post}}{{post.title}}{{/link-to}}</h2>
+      {{post.body}}
+    </article>
+    {{/each}}
+
+Now take a look at `http://localhost:4200` and a link should appear. **Click it!** And now you're at the page for our blog post.
 
 ### 12. Blog comment
 
@@ -324,3 +379,8 @@ TODO: Add acceptance test for our blog post models showing up
 ### 13. Submitting a comment
 
 0. Add form to submit a comment
+
+### More?
+
+0. Paginate homepage?
+0. Make archive page for previous blog posts?

--- a/outline.md
+++ b/outline.md
@@ -120,13 +120,12 @@ Looking a little more into the body of the code, we see that our model is specif
     });
 
 #### Test our blog post model
-Testing can seem daunting if you put it off for too long so lets get right to it and write a test for that model we just created. Ember-CLI has us covered, again, with the generators. We are going to use a generator to create our `blog-post` test.
+Testing can seem daunting if you put it off for too long so lets get right to it and write a test for that model we just created. Ember-CLI has us covered. Our model generation above also generated a test module for our blog post model:
 
-    $ ember generate model-test blog-post
-    installing
-      create tests/unit/models/blog-post-test.js
+    $ ls tests/unit/models
+    blog-post-test.js
 
-Pretty handy, huh? Let's look at what ember-cli generated for us...
+Pretty cool, huh? Let's open up `tests/unit/models/blog-post-test.js` and see what Ember-CLI generated for us:
 
     import {
       moduleForModel,

--- a/outline.md
+++ b/outline.md
@@ -286,13 +286,30 @@ Instead of testing from the command line like before, let's try it out from the 
 
 Now we're just about ready to start diving in and actually creating blog posts and looking at them - just one thing missing:  A backend to store that data!  Ember is a client side framework and so when we have data that we want to persist, we need a backend API.  Luckily, for this workshop we've set one up for you at https://sandiego-ember-cli-101.herokuapp.com supporting the following endpoints
 
-|Verb|path|Description|
-|---------------------|
-|GET|/blog-posts|List of blog posts|
-|POST|/blog-posts|Create a blog post|
-|GET|/blog-posts/:id|Retrieve a post|
-|PUT|/blog-posts/:id|Update a post|
-|DELETE|/blog-posts/:id|Delete a post|
+<table>
+    <thead>
+        <tr>
+            <th>Verb</th><th>path</th><th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>GET</td><td>/blog-posts</td><td>List of blog posts</td>
+        </tr>
+        <tr>
+            <td>POST</td><td>/blog-posts</td><td>Create a blog post</td>
+        </tr>
+        <tr>
+            <td>GET</td><td>/blog-posts/:id</td><td>Retrieve a post</td>
+        </tr>
+        <tr>
+            <td>PUT</td><td>/blog-posts/:id</td><td>Update a post</td>
+        </tr>
+        <tr>
+            <td>DELETE</td><td>/blog-posts/:id</td><td>Delete a post</td>
+        </tr>
+    </tbody>
+</table>
 
 This particular API was built with Ruby on Rails and thus uses the rails standard snake_case for the JSON that it sends. But Ember expects things to be camelCase, so how can we connect these two nicely?  Luckily, Ember Data already has us covered with the concept of an adapter, which allows us to specify how to adapt the format from any API. We can set up an adapter at the level of an individual model, but since we'll be using the same API for all of our models, let's set one up for the entire application:
 

--- a/outline.md
+++ b/outline.md
@@ -56,23 +56,23 @@ Now that you have an Ember-CLI generated project, let's step inside and start ex
     README.md               bower_components        package.json            tests
     app                     config                  public                  vendor
 
-##### 1. package.json and node_modules
+##### package.json and node_modules
 The first things to notice is the file `package.json` and the directory `node_modules`. These are from npm, and if you're new to NPM, take a look at what is in the `package.json` file.  This file contains information about packaging up your application as a module itself, but more importantly for our purposes it contains information about what npm modules are required to run and develop our app. When using ember-cli you won't often come in here and edit this ourselves directly however you'll see that the packages needed for broccoli and ember-cli are specified here. If you were to install any ember-cli-addons yourself, you would see them show up in here as well. The packages specified in `package.json` will be installed under `node_modules/`.
 
-##### 2. bower.json and bower_components
+##### bower.json and bower_components
 The next thing to look at is the file `bower.json` and the `bower_components` directory. This coupling is similar to that of the prior. Bower has become the defacto standard in package management for front end applications and our Ember-CLI application will use it to manage our dependencies. If you open up that file you'll see that our application comes out of the box with not only Ember itself but jQuery, Ember Data (a powerful data persistence library), and qunit (testing framework).
 
-##### 3. tests
+##### tests
 Ember-CLI comes out-of-the box with a testing framework and ember-cli provides some context and helpers, making it easier to test our applications. You can test models, routes, controllers and components. Possibly the most useful types of tests you can write, however, are unit and acceptance tests.
 
 Unit tests allow us to hone in on a specific functionality and does not require the entire ember application be running. This makes it easy to setup and quickly test functional pieces of our application. Acceptance tests, also called integration tests, are used to test workflows of your app. They emulate user interactions throughout your application and using helpers you can assert the expected functionality.
 
-#### 4. public and vendor
+#### public and vendor
 You may be wondering where images, fonts and other assets go. The answer is the `public` directory. These will be served at the root of your application.
 
 Similarly, you may have dependencies that are not in bower - stylesheets or javascripts. These can be stored in the `vendor` directory. Loading vendor files is not something we will cover in this workshop.
 
-##### 5. The 'app' directory
+##### The 'app' directory
 The app directory is where we're going to put all of our application code.  It is carefully structured with an appropriate place for each type of module:
 
     $ ls app
@@ -89,7 +89,7 @@ Some of these may sound familiar to you, while others may be brand new.  Don't w
 
 ### 9. Blog post model
 
-#### 1. Make a blog post model
+#### Make a blog post model
 For our test application, we're going to create a blog.  Let's start off by using a generator to create a model for the blogPost.  We'll give it a couple of basic fields and take a look at what happens.
 
     $ ember generate model blogPost title:string body:string
@@ -119,7 +119,7 @@ Looking a little more into the body of the code, we see that our model is specif
       publishedDate: DS.attr('date')
     });
 
-#### 2. Test our blog post model
+#### Test our blog post model
 Testing can seem daunting if you put it off for too long so lets get right to it and write a test for that model we just created. Ember-CLI has us covered, again, with the generators. We are going to use a generator to create our `blog-post` test.
 
     $ ember generate model-test blog-post
@@ -156,7 +156,7 @@ Since we have about as much as we can test in here already for our small model, 
 
 ### 10. Initial blog posts route
 
-#### 1. Create the route
+#### Create the route
 If we want to actually see our model in our website, we need to actually render something to HTML.  Ember's view layer places routes and their associated URLs front and center in the architecture.  The way to show something is to create a route and associated template.  Let's start once again from a generator:
 
     $ ember generate route blog-posts --type=resource
@@ -188,7 +188,7 @@ We can see that the route to 'blog-posts' is being set up... we'll come back to 
     export default Ember.Route.extend({
     });
 
-#### 2. Update the template
+#### Update the template
 This is where we'll set up any data we need to render the template.  And speaking of the template, let's look at what `app/templates/blog-posts.hbs` contains:
 
     {{outlet}}
@@ -204,7 +204,7 @@ Our 'My Blog' header should appear nicely beneath our application header.
 
 **ProTip™** Ember-CLI uses live-reloading to persist changes to the browser without the need of reloading. Neat!
 
-#### 3. Handlebars link-to helper
+#### Handlebars link-to helper
 
 It would be useful to provide a link at the root of our application to our blog posts so that when we visit `http://localhost:4200` we can easily jump to our blog-posts. To add this link open up the `app/templates/application.hbs` file and see what is there:
 
@@ -221,7 +221,7 @@ We're only going to add one small line here to link to our `blog-posts` route an
 
 Now take a look at `http://localhost:4200` and a link should appear. **Click it!** And now you're at the blog-posts route. That was easy.
 
-#### 4. Acceptance testing
+#### Acceptance testing
 With some user interaction added to our application we can now create an acceptance test. So what did we just do? We opened up the root of our application, clicked a link, and it brought us to the `blog-posts` route. Let's make a test for that! Even though there is only one link right now we will add others so we can name this test `app-navigation` and can add to it as we add more links to our `application.hbs`.
 
     $ ember generate acceptance-test app-navigation

--- a/outline.md
+++ b/outline.md
@@ -122,27 +122,27 @@ Looking a little more into the body of the code, we see that our model is specif
 #### 2. Test our blog post model
 Testing can seem daunting if you put it off for too long so lets get right to it and write a test for that model we just created. Ember-CLI has us covered, again, with the generators. We are going to use a generator to create our `blog-post` test.
 
-	$ ember generate model-test blog-post
-	installing
-	  create tests/unit/models/blog-post-test.js
-	  
+    $ ember generate model-test blog-post
+    installing
+      create tests/unit/models/blog-post-test.js
+
 Pretty handy, huh? Let's look at what ember-cli generated for us...
 
-	import {
-	  moduleForModel,
-	  test
-	} from 'ember-qunit';
+    import {
+      moduleForModel,
+      test
+    } from 'ember-qunit';
 
-	moduleForModel('blog-post', {
-	  // Specify the other units that are required for this test.
+    moduleForModel('blog-post', {
+      // Specify the other units that are required for this test.
 
-	});
+    });
 
-	test('it exists', function(assert) {
-	  var model = this.subject();
-	  // var store = this.store();
-	  assert.ok(!!model);
-	});
+    test('it exists', function(assert) {
+      var model = this.subject();
+      // var store = this.store();
+      assert.ok(!!model);
+    });
 
 That looks like a lot! First is the import statement. This is how, using ES6 module syntax, we can import the parts of the `ember-qunit` package we need for our test.
 
@@ -208,68 +208,68 @@ Our 'My Blog' header should appear nicely beneath our application header.
 
 It would be useful to provide a link at the root of our application to our blog posts so that when we visit `http://localhost:4200` we can easily jump to our blog-posts. To add this link open up the `app/templates/application.hbs` file and see what is there:
 
-	<h2 id="title">Welcome to Ember.js</h2>
+    <h2 id="title">Welcome to Ember.js</h2>
 
-	{{outlet}}
+    {{outlet}}
 
 We're only going to add one small line here to link to our `blog-posts` route and that uses a special handlebars template called `link-to`. Imagine that! Update your `application.hbs` so that it looks like this:
 
-	<h2 id="title">Welcome to Ember.js</h2>
-	{{link-to 'Blog Posts' 'blog-posts'}}
+    <h2 id="title">Welcome to Ember.js</h2>
+    {{link-to 'Blog Posts' 'blog-posts'}}
 
-	{{outlet}}
+    {{outlet}}
 
 Now take a look at `http://localhost:4200` and a link should appear. **Click it!** And now you're at the blog-posts route. That was easy.
 
 #### 4. Acceptance testing
 With some user interaction added to our application we can now create an acceptance test. So what did we just do? We opened up the root of our application, clicked a link, and it brought us to the `blog-posts` route. Let's make a test for that! Even though there is only one link right now we will add others so we can name this test `app-navigation` and can add to it as we add more links to our `application.hbs`.
 
-	$ ember generate acceptance-test app-navigation
-	installing
-	  create tests/acceptance/app-navigation-test.js
-	
+    $ ember generate acceptance-test app-navigation
+    installing
+      create tests/acceptance/app-navigation-test.js
+
 Open the newly created file `tests/acceptance/app-navigation-test.js` and see what is there:
 
-	import Ember from 'ember';
-	import {
-	  module,
-	  test
-	} from 'qunit';
-	import startApp from 'workshop/tests/helpers/start-app';
+    import Ember from 'ember';
+    import {
+      module,
+      test
+    } from 'qunit';
+    import startApp from 'workshop/tests/helpers/start-app';
 
-	var application;
+    var application;
 
-	module('Acceptance: AppNavigation', {
-	  beforeEach: function() {
-	    application = startApp();
-	  },
-	
-	  afterEach: function() {
-	    Ember.run(application, 'destroy');
-	  }
-	});
+    module('Acceptance: AppNavigation', {
+      beforeEach: function() {
+        application = startApp();
+      },
 
-	test('visiting /app-navigation', function(assert) {
-	  visit('/app-navigation');
+      afterEach: function() {
+        Ember.run(application, 'destroy');
+      }
+    });
 
-	  andThen(function() {
-	    assert.equal(currentPath(), 'app-navigation');
-	  });
-	});
+    test('visiting /app-navigation', function(assert) {
+      visit('/app-navigation');
+
+      andThen(function() {
+        assert.equal(currentPath(), 'app-navigation');
+      });
+    });
 
 Hm... this isn't exactly what we want. We don't have an 'app-navigation' route, but the ember generator assumed we did based on the naming. Let's remove that test and add one for our link-to helper instead.
 
-	test('clicking blog posts link visits /blog-posts', function(assert) {
-	  visit('/');
-	  
-	  andThen(function() {
-	  	click('a:contains("Blog Posts")');
-	  });
+    test('clicking blog posts link visits /blog-posts', function(assert) {
+      visit('/');
 
-	  andThen(function() {
-	    assert.equal(currentPath(), 'blog-posts.index');
-	  });
-	});
+      andThen(function() {
+          click('a:contains("Blog Posts")');
+      });
+
+      andThen(function() {
+        assert.equal(currentPath(), 'blog-posts.index');
+      });
+    });
 
 There are a few helpers here that we will use **a lot** when writing acceptance tests.
 
@@ -305,25 +305,25 @@ This particular API was built with Ruby on Rails and thus uses the rails standar
 
 Let's open up that adapter and see what is there:
 
-	import DS from 'ember-data';
+    import DS from 'ember-data';
 
-	export default DS.RESTAdapter.extend({
-	});
+    export default DS.RESTAdapter.extend({
+    });
 
 Not much going on, we're using an Ember Data builtin adapter called the RESTAdapter. Building a custom adapter isn't too hard, but luckily for us we don't need to... Ember Data already has an adapter custom built for Rails APIs. We just need to update this file to use that special adapter as follows:
 
-	import DS from 'ember-data';
+    import DS from 'ember-data';
 
-	export default DS.ActiveModelAdapter.extend({
-	});
+    export default DS.ActiveModelAdapter.extend({
+    });
 
 Finally, to point our ember app at the API we've set up, we simply restart our 'ember serve' using the proxy option to point Ember to the api we want to access:
 
     $ ember serve --proxy https://sandiego-ember-cli-101.herokuapp.com
-	version: 0.2.1
-	Proxying to https://sandiego-ember-cli-101.herokuapp.com
-	Livereload server on port 35729
-	Serving on http://localhost:4200/
+    version: 0.2.1
+    Proxying to https://sandiego-ember-cli-101.herokuapp.com
+    Livereload server on port 35729
+    Serving on http://localhost:4200/
 
 ### Create New Blog Post
 

--- a/outline.md
+++ b/outline.md
@@ -310,20 +310,17 @@ Let's test that the blog posts from our API show up on the homepage.
 
 TODO: Add acceptance test for our blog post models showing up
 
-### Create New Blog Post
+### 11. Additional Blog post route(s)
 
-Now that we have our `blog-posts` route setup we can add a create route so that we can start actually creating data for our application.
-
-###    Additional Blog post route(s)
-
-0. Add new route with template.  Cover binding, highlight nesting
 0. Add show route with template.
-0. Add index page.
-0. Make blog posts show up on the homepage?
+0. Paginate homepage?
+0. Make archive page for previous blog posts?
 
-### 13. Blog comment
+### 12. Blog comment
+
 0. Make blog comment model and relate to post
 0. Make comments show up on blog post detail page
 
-### 14. Submitting a comment
+### 13. Submitting a comment
+
 0. Add form to submit a comment

--- a/outline.md
+++ b/outline.md
@@ -85,7 +85,70 @@ Some of these may sound familiar to you, while others may be brand new.  Don't w
 0. `ember serve`
 0. http://localhost:4200
 
-### 8. Setup ember-data with our API endpoint? Or setup fixtures?
+### 8 Diversion: Accessing our API with ember-data
+
+Ember is a client side framework and so when we have data that we want to persist, we need a backend API.  We want an API to serve up our blog posts and allow users to view and submit comments.
+
+We could use fixtures or a mock API, but some friendly back-end developers have already made a working API for us so let's use that.
+
+Our API is setup at https://sandiego-ember-cli-101.herokuapp.com supporting the following endpoints
+
+<table>
+    <thead>
+        <tr>
+            <th>Verb</th><th>path</th><th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>GET</td><td>/blog-posts</td><td>List of blog posts</td>
+        </tr>
+        <tr>
+            <td>GET</td><td>/blog-posts/:id</td><td>Retrieve a post</td>
+        </tr>
+        <tr>
+            <td>PUT</td><td>/blog-posts/:id</td><td>Update a post</td>
+        </tr>
+        <tr>
+            <td>DELETE</td><td>/blog-posts/:id</td><td>Delete a post</td>
+        </tr>
+    </tbody>
+</table>
+
+Our API uses snake_case in the JSON it sends, common for Ruby on Rails APIs. Ember expects everything to be camelCase, so how can we connect these two nicely? Fortunately, we can use an Ember Data adapter to consumer our API and adapter it to the style we use in Ember.
+
+We can set up an adapter at the level of an individual model, but since we'll be using the same API for all of our models, let's set one up for the entire application:
+
+    $ ember g adapter application
+    version: 0.2.0
+      installing
+        create app/adapters/application.js
+      installing
+        create tests/unit/adapters/application-test.js
+
+Let's open up that adapter and see what is there:
+
+    import DS from 'ember-data';
+
+    export default DS.RESTAdapter.extend({
+    });
+
+We're using an Ember Data builtin adapter called the RESTAdapter. Building a custom adapter isn't too hard, but we don't need to because Ember Data already has an adapter custom built for Rails APIs.
+
+Let's update our file to use the Ember adapter for Rails APIs:
+
+    import DS from 'ember-data';
+
+    export default DS.ActiveModelAdapter.extend({
+    });
+
+Finally, to point our Ember app at the API we've set up, let's restart 'ember serve' using the proxy option to point Ember to the api we want to access:
+
+    $ ember serve --proxy https://sandiego-ember-cli-101.herokuapp.com
+    version: 0.2.1
+    Proxying to https://sandiego-ember-cli-101.herokuapp.com
+    Livereload server on port 35729
+    Serving on http://localhost:4200/
 
 ### 9. Blog post model
 
@@ -246,67 +309,6 @@ With some user interaction added to our application we can now create an accepta
 Let's test that the blog posts from our API show up on the homepage.
 
 TODO: Add acceptance test for our blog post models showing up
-
-
-### 11 Diversion: API and serializers
-
-Now we're just about ready to start diving in and actually creating blog posts and looking at them - just one thing missing:  A backend to store that data!  Ember is a client side framework and so when we have data that we want to persist, we need a backend API.  Luckily, for this workshop we've set one up for you at https://sandiego-ember-cli-101.herokuapp.com supporting the following endpoints
-
-<table>
-    <thead>
-        <tr>
-            <th>Verb</th><th>path</th><th>Description</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td>GET</td><td>/blog-posts</td><td>List of blog posts</td>
-        </tr>
-        <tr>
-            <td>POST</td><td>/blog-posts</td><td>Create a blog post</td>
-        </tr>
-        <tr>
-            <td>GET</td><td>/blog-posts/:id</td><td>Retrieve a post</td>
-        </tr>
-        <tr>
-            <td>PUT</td><td>/blog-posts/:id</td><td>Update a post</td>
-        </tr>
-        <tr>
-            <td>DELETE</td><td>/blog-posts/:id</td><td>Delete a post</td>
-        </tr>
-    </tbody>
-</table>
-
-This particular API was built with Ruby on Rails and thus uses the rails standard snake_case for the JSON that it sends. But Ember expects things to be camelCase, so how can we connect these two nicely?  Luckily, Ember Data already has us covered with the concept of an adapter, which allows us to specify how to adapt the format from any API. We can set up an adapter at the level of an individual model, but since we'll be using the same API for all of our models, let's set one up for the entire application:
-
-    $ ember g adapter application
-    version: 0.2.0
-      installing
-        create app/adapters/application.js
-      installing
-        create tests/unit/adapters/application-test.js
-
-Let's open up that adapter and see what is there:
-
-    import DS from 'ember-data';
-
-    export default DS.RESTAdapter.extend({
-    });
-
-Not much going on, we're using an Ember Data builtin adapter called the RESTAdapter. Building a custom adapter isn't too hard, but luckily for us we don't need to... Ember Data already has an adapter custom built for Rails APIs. We just need to update this file to use that special adapter as follows:
-
-    import DS from 'ember-data';
-
-    export default DS.ActiveModelAdapter.extend({
-    });
-
-Finally, to point our ember app at the API we've set up, we simply restart our 'ember serve' using the proxy option to point Ember to the api we want to access:
-
-    $ ember serve --proxy https://sandiego-ember-cli-101.herokuapp.com
-    version: 0.2.1
-    Proxying to https://sandiego-ember-cli-101.herokuapp.com
-    Livereload server on port 35729
-    Serving on http://localhost:4200/
 
 ### Create New Blog Post
 


### PR DESCRIPTION
Changes:
- Fix indentation and fix some broken markdown
- Remove model test generator because the model generator already made a test
- Explain API adapter earlier
- Remove blog-posts resource and put blog posts on the homepage
- Update next steps at end of outline
- Add page for individual blog posts (demonstrates link-to helper)

I left these as TODO:
- Write an acceptance test for homepage
- Write a unit test for route

The link-to helper explanation that was removed should be repurposed for the to-be-written show blog post page material.
